### PR TITLE
Autolinking Requirements

### DIFF
--- a/RNFaceApi.podspec
+++ b/RNFaceApi.podspec
@@ -14,7 +14,7 @@ Pod::Spec.new do |s|
 
   s.source       = { http: "file:#{source}" }
   s.ios.deployment_target = '9.0'
-  s.source_files = '*.{h,m}'
+  s.source_files = 'ios/**/*.{h,m}'
   s.dependency 'FaceSDK', '3.0.798'
   s.dependency 'React'
 end

--- a/RNFaceApi.podspec
+++ b/RNFaceApi.podspec
@@ -1,6 +1,7 @@
 require 'json'
 
 package = JSON.parse(File.read(File.join(__dir__, 'package.json')))
+source = File.join(__dir__, 'ios')
 
 Pod::Spec.new do |s|
   s.name         = 'RNFaceApi'
@@ -11,7 +12,7 @@ Pod::Spec.new do |s|
   s.authors      = { 'RegulaForensics' => 'support@regulaforensics.com' }
   s.homepage     = 'https://regulaforensics.com'
 
-  s.source       = { http: "file:#{__dir__}" }
+  s.source       = { http: "file:#{source}" }
   s.ios.deployment_target = '9.0'
   s.source_files = '*.{h,m}'
   s.dependency 'FaceSDK', '3.0.798'

--- a/RNFaceApi.podspec
+++ b/RNFaceApi.podspec
@@ -1,9 +1,9 @@
 require 'json'
 
-package = JSON.parse(File.read(File.join(__dir__, '../package.json')))
+package = JSON.parse(File.read(File.join(__dir__, 'package.json')))
 
 Pod::Spec.new do |s|
-  s.name         = "RNFaceApi"
+  s.name         = 'RNFaceApi'
   s.version      = package['version']
   s.summary      = package['description']
   s.license      = package['license']
@@ -11,9 +11,9 @@ Pod::Spec.new do |s|
   s.authors      = { 'RegulaForensics' => 'support@regulaforensics.com' }
   s.homepage     = 'https://regulaforensics.com'
 
-  s.source       = { :http => 'file:' + __dir__ }
+  s.source       = { http: "file:#{__dir__}" }
   s.ios.deployment_target = '9.0'
-  s.source_files  = "*.{h,m}"
+  s.source_files = '*.{h,m}'
   s.dependency 'FaceSDK', '3.0.798'
   s.dependency 'React'
 end


### PR DESCRIPTION
This Pull Request fixes the following issue: #6 

Module structure and the `.podspec` file are changed to meet the requirements of the auto-linking package.

We have to keep our `.podspec` file at the root of the repo and make sure paths are correct.

References: 
[Autolinking migration](https://github.com/react-native-community/cli/blob/master/docs/autolinking.md#what-do-i-need-to-have-in-my-package-to-make-it-work)
[.podspec Example](https://github.com/react-native-webview/react-native-webview/blob/master/react-native-webview.podspec)