### PR TITLE
Fix: Root Controller for start capture view

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1509,7 +1509,7 @@ export default class FaceSDK {
     static setLocalizationDictionary(dictionary: Record<string, string>, successCallback: (response: string) => void, errorCallback?: (error: string) => void): void
     static setRequestHeaders(headers: Record<string, string>, successCallback: (response: string) => void, errorCallback?: (error: string) => void): void
     static setCustomization(config: Customization, successCallback: (response: string) => void, errorCallback?: (error: string) => void): void
-    static isInitialized(successCallback: (response: string) => void, errorCallback?: (error: string) => void): void
+    static isInitialized(successCallback: (response: boolean) => void, errorCallback?: (error: string) => void): void
     static initialize(config: InitConfig | null, successCallback: (response: string) => void, errorCallback?: (error: string) => void): void
     static deinitialize(successCallback: (response: string) => void, errorCallback?: (error: string) => void): void
     static startFaceCapture(config: FaceCaptureConfig | null, successCallback: (response: string) => void, errorCallback?: (error: string) => void): void

--- a/ios/RNFaceApi.m
+++ b/ios/RNFaceApi.m
@@ -136,7 +136,8 @@ NSString* RFSWOnCustomButtonTappedEvent = @"onCustomButtonTappedEvent";
 
 - (void) startFaceCapture:(NSDictionary*)config :(RFSWCallback)callback {
     dispatch_async(dispatch_get_main_queue(), ^{
-        [RFSFaceSDK.service presentFaceCaptureViewControllerFrom:[UIApplication sharedApplication].windows.lastObject.rootViewController
+        UIViewController *currentViewController = [[[UIApplication sharedApplication] keyWindow] rootViewController];
+        [RFSFaceSDK.service presentFaceCaptureViewControllerFrom:currentViewController
                                                             animated:true
                                                        configuration:[RFSWConfig faceCaptureConfigFromJSON:config]
                                                            onCapture:[self faceCaptureCompletion:callback]
@@ -150,7 +151,8 @@ NSString* RFSWOnCustomButtonTappedEvent = @"onCustomButtonTappedEvent";
 
 - (void) startLiveness:(NSDictionary*)config :(RFSWCallback)callback {
     dispatch_async(dispatch_get_main_queue(), ^{
-        [RFSFaceSDK.service startLivenessFrom:[UIApplication sharedApplication].windows.lastObject.rootViewController
+        UIViewController *currentViewController = [[[UIApplication sharedApplication] keyWindow] rootViewController];
+        [RFSFaceSDK.service startLivenessFrom:currentViewController
                                                 animated:true
                                            configuration:[RFSWConfig livenessConfigFromJSON:config]
                                               onLiveness:[self livenessCompletion:callback]

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@regulaforensics/react-native-face-api",
-  "version": "6.4.471",
+  "version": "6.4.472",
   "description": "React Native module for compairing faces using phone`s camera",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
There's a bug in the current way the `rootController` gets attached to the presenting view for the `startCapture` and `startLiveness` call. In Expo it's attaching to the "Development Window" which silently fails. I copied the logic from the Document Reader (where it works) and implemented it here.

Also, minor type fix.

PS: Would be nice if the error callbacks actually get hooked up to the native error calls.